### PR TITLE
Various updates to the decoding pipeline

### DIFF
--- a/src/DSharpPlus.VoiceLink/DiscordIpDiscoveryPacket.cs
+++ b/src/DSharpPlus.VoiceLink/DiscordIpDiscoveryPacket.cs
@@ -41,6 +41,7 @@ namespace DSharpPlus.VoiceLink
             BinaryPrimitives.WriteUInt16BigEndian(dataSpan[2..4], ipDiscovery.Length);
             BinaryPrimitives.WriteUInt32BigEndian(dataSpan[4..8], ipDiscovery.Ssrc);
             Encoding.UTF8.TryGetBytes(ipDiscovery.Address, dataSpan[8..72], out _);
+            dataSpan[71] = 0; // Need to null-terminate the IP string
             BinaryPrimitives.WriteUInt16BigEndian(dataSpan[72..74], ipDiscovery.Port);
 
             return data;

--- a/src/DSharpPlus.VoiceLink/Opus/OpusNativeMethods.Decoder.cs
+++ b/src/DSharpPlus.VoiceLink/Opus/OpusNativeMethods.Decoder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace DSharpPlus.VoiceLink.Opus
@@ -20,7 +21,7 @@ namespace DSharpPlus.VoiceLink.Opus
         /// <param name="channels">Number of channels (1 or 2) to decode.</param>
         /// <returns><see cref="OpusErrorCode.Ok"/> or other error codes.</returns>
         [LibraryImport("opus", EntryPoint = "opus_decoder_create")]
-        public static unsafe partial OpusDecoder* DecoderCreate(OpusSampleRate sampleRate, int channels, out OpusErrorCode* error);
+        public static unsafe partial IntPtr DecoderCreate(OpusSampleRate sampleRate, int channels, out OpusErrorCode* error);
 
         /// <summary>
         /// Initializes a previously allocated decoder state. The state must be at least the size returned by <see cref="DecoderGetSize(int)"/>. This is intended for applications which use their own allocator instead of malloc.
@@ -30,7 +31,7 @@ namespace DSharpPlus.VoiceLink.Opus
         /// <param name="channels">Number of channels (1 or 2) to decode.</param>
         /// <returns><see cref="OpusErrorCode.Ok"/> or other error codes.</returns>
         [LibraryImport("opus", EntryPoint = "opus_decoder_init")]
-        public static unsafe partial OpusErrorCode DecoderInit(OpusDecoder* decoder, OpusSampleRate sampleRate, int channels);
+        public static unsafe partial OpusErrorCode DecoderInit(IntPtr decoder, OpusSampleRate sampleRate, int channels);
 
         /// <summary>
         /// Decode an Opus packet.
@@ -43,11 +44,11 @@ namespace DSharpPlus.VoiceLink.Opus
         /// <param name="decodeFec">Flag (0 or 1) to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
         /// <returns>Number of decoded samples or an <see cref="OpusErrorCode"/></returns>
         [LibraryImport("opus", EntryPoint = "opus_decode")]
-        public static unsafe partial int Decode(OpusDecoder* decoder, byte* data, int length, byte* pcm, int frameSize, int decodeFec);
+        public static unsafe partial int Decode(IntPtr decoder, byte* data, int length, byte* pcm, int frameSize, int decodeFec);
 
-        /// <inheritdoc cref="Decode(OpusDecoder*, byte*, int, byte*, int, int)"/>
+        /// <inheritdoc cref="Decode(IntPtr, byte*, int, byte*, int, int)"/>
         [LibraryImport("opus", EntryPoint = "opus_decode_float")]
-        public static unsafe partial int DecodeFloat(OpusDecoder* decoder, byte* data, int length, byte* pcm, int frameSize, int decodeFec);
+        public static unsafe partial int DecodeFloat(IntPtr decoder, byte* data, int length, byte* pcm, int frameSize, int decodeFec);
 
         /// <summary>
         /// Perform a CTL function on an Opus decoder.
@@ -56,14 +57,14 @@ namespace DSharpPlus.VoiceLink.Opus
         /// <param name="decoder">Decoder state.</param>
         /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in Generic CTLs or Decoder related CTLs.</param>
         [LibraryImport("opus", EntryPoint = "opus_decoder_ctl")]
-        public static unsafe partial OpusErrorCode DecoderControl(OpusDecoder* decoder, OpusControlRequest request, out int value);
+        public static unsafe partial OpusErrorCode DecoderControl(IntPtr decoder, OpusControlRequest request, out int value);
 
         /// <summary>
-        /// Frees an OpusDecoder allocated by <see cref="DecoderCreate(OpusSampleRate, int, out OpusErrorCode)"/>.
+        /// Frees an OpusDecoder allocated by <see cref="DecoderCreate(OpusSampleRate, int, out OpusErrorCode*)"/>.
         /// </summary>
         /// <param name="decoder">State to be freed.</param>
         [LibraryImport("opus", EntryPoint = "opus_decoder_destroy")]
-        public static unsafe partial void DecoderDestroy(OpusDecoder* decoder);
+        public static unsafe partial void DecoderDestroy(IntPtr decoder);
 
         /// <summary>
         /// Gets the number of samples of an Opus packet.
@@ -73,6 +74,6 @@ namespace DSharpPlus.VoiceLink.Opus
         /// <param name="length">Length of packet.</param>
         /// <returns>Number of samples or <see cref="OpusErrorCode.BadArg"/> or <see cref="OpusErrorCode.InvalidPacket"/>.</returns>
         [LibraryImport("opus", EntryPoint = "opus_decoder_get_nb_samples")]
-        public static unsafe partial int DecoderGetNbSamples(OpusDecoder* decoder, byte* data, int length);
+        public static unsafe partial int DecoderGetNbSamples(IntPtr decoder, byte* data, int length);
     }
 }

--- a/src/DSharpPlus.VoiceLink/Rtp/RtpUtilities.cs
+++ b/src/DSharpPlus.VoiceLink/Rtp/RtpUtilities.cs
@@ -75,5 +75,11 @@ namespace DSharpPlus.VoiceLink.Rtp
                 Ssrc = BinaryPrimitives.ReadUInt32BigEndian(source[8..12])
             };
         }
+
+        public static ushort GetHeaderExtensionLength(ReadOnlySpan<byte> rtpPayload)
+        {
+            // offset by two to ignore the profile marker
+            return BinaryPrimitives.ReadUInt16BigEndian(rtpPayload[2..]);
+        }
     }
 }

--- a/src/DSharpPlus.VoiceLink/Rtp/RtpUtilities.cs
+++ b/src/DSharpPlus.VoiceLink/Rtp/RtpUtilities.cs
@@ -76,6 +76,12 @@ namespace DSharpPlus.VoiceLink.Rtp
             };
         }
 
+        /// <summary>
+        /// Gets the length in bytes of an RTP header extension. The extension will prefix the RTP payload.
+        /// Use <see cref="RtpHeader.HasExtension"/> to determined whether an RTP packet includes an extension.
+        /// </summary>
+        /// <param name="rtpPayload">The RTP payload that is prefixed by a header extension.</param>
+        /// <returns>The byte length of the extension.</returns>
         public static ushort GetHeaderExtensionLength(ReadOnlySpan<byte> rtpPayload)
         {
             // offset by two to ignore the profile marker

--- a/src/DSharpPlus.VoiceLink/VoiceLinkConnection.cs
+++ b/src/DSharpPlus.VoiceLink/VoiceLinkConnection.cs
@@ -329,7 +329,7 @@ namespace DSharpPlus.VoiceLink
                     const int sampleRate = 48000; // 48 kHz
                     const double frameDuration = 0.020; // 20 milliseconds
                     const int frameSize = (int)(sampleRate * frameDuration); // 960 samples
-                    const int bufferSize = frameSize * 2; // Stereo audio
+                    const int bufferSize = frameSize * 2 * sizeof(short); // Stereo audio + opus PCM units are 16 bits
 
                     // Allocate the buffer for the PCM data
                     Span<byte> audioBuffer = voiceLinkUser._audioPipe.Writer.GetSpan(bufferSize);

--- a/src/DSharpPlus.VoiceLink/VoiceLinkConnection.cs
+++ b/src/DSharpPlus.VoiceLink/VoiceLinkConnection.cs
@@ -322,7 +322,7 @@ namespace DSharpPlus.VoiceLink
                     Span<byte> audioBuffer = voiceLinkUser._audioPipe.Writer.GetSpan(bufferSize);
 
                     // Decode the Opus packet
-                    voiceLinkUser._opusDecoder.Decode(opusPacket, audioBuffer, hasPacketLoss);
+                    voiceLinkUser._opusDecoder.Decode(opusPacket, audioBuffer, frameSize, hasPacketLoss);
 
                     // Write the audio to the pipe
                     voiceLinkUser._audioPipe.Writer.Advance(bufferSize);


### PR DESCRIPTION
This PR targets a few things that were preventing successful audio decoding:

- `VoiceLinkConnection.cs` now ignores RTP header extensions.
- Pass the frame size into `OpusNativeMethods#Decode`, rather than using the number of frames in the buffer.
- Refactor `OpusDecoder.cs` and `OpusNativeMethods.Decoder.cs` to store/return a pointer to the created decoder state, rather than trying to use a pointer to the struct that was originally returned, which was not referring to the created state object.
- Account for Opus using 16-bit PCM units when allocating the PCM buffer.
- Limit the decrypted audio buffer to the length of the data, rather than the entirety of the rented buffer. Unsure if this actually has an effect on decoding but I think it's a safer practice regardless.
- Minor changes to error logging.

Hopefully this is useful, let me know of any issues 😄.